### PR TITLE
feat: Use apollo RetryLink to reduce broken deploys

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -295,7 +295,7 @@ export type PricingPageProps = { teamMembers: TeamMemberFragment[] }
 export const getStaticProps: GetStaticProps<PricingPageProps> = async (
   _context
 ) => {
-  const { data: teamMembers, error: teamMembersError } = await getTeamMembers()
+  const { data: teamMembers } = await getTeamMembers()
 
   if (!teamMembers) {
     return { notFound: true }
@@ -307,6 +307,5 @@ export const getStaticProps: GetStaticProps<PricingPageProps> = async (
       'We are building a flexible, scalable solution to application delivery.',
     teamMembers,
     footerVariant: FooterVariant.kitchenSink,
-    errors: [...(teamMembersError ? [teamMembersError] : [])],
   })
 }

--- a/pages/careers/index.tsx
+++ b/pages/careers/index.tsx
@@ -292,6 +292,6 @@ export const getStaticProps = async () => {
       'We are a growing team working on interesting problems in the cloud with Kubernetes, Elixir, Go, and React. We’re always interested in hiring new talent!',
     footerVariant: FooterVariant.kitchenSink,
     jobs: jobs || [],
-    errors: [...(jobsError ? [jobsError] : [])],
+    errors: [...(jobsError ? [jobsError.message] : [])],
   })
 }

--- a/src/apollo-client.ts
+++ b/src/apollo-client.ts
@@ -1,16 +1,30 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client'
+import { ApolloClient, ApolloLink, InMemoryCache } from '@apollo/client'
+import { HttpLink } from '@apollo/client/link/http'
+import { RetryLink } from '@apollo/client/link/retry'
+
+const pluralRetryLink = new RetryLink()
+
+const pluralHttpLink = new HttpLink({ uri: 'https://app.plural.sh/gql' })
+const pluralLink = ApolloLink.from([pluralRetryLink, pluralHttpLink])
 
 const client = new ApolloClient({
-  uri: 'https://app.plural.sh/gql',
+  link: pluralLink,
   cache: new InMemoryCache(),
 })
 
 const directusToken = process.env.DIRECTUS_ACCESS_TOKEN
 
-export const directusClient = new ApolloClient({
+const directusRetryLink = new RetryLink()
+
+const directusHttpLink = new HttpLink({
   uri: `https://directus.plural.sh/graphql${
     directusToken ? `?access_token=${directusToken}` : ''
   }`,
+})
+const directusLink = ApolloLink.from([directusRetryLink, directusHttpLink])
+
+export const directusClient = new ApolloClient({
+  link: directusLink,
   cache: new InMemoryCache(),
 })
 


### PR DESCRIPTION
Builds keep breaking due to networking errors. Adding ability to retry Apollo requests to help reduce this.