### PR TITLE
add security and compliance portal to resources

### DIFF
--- a/src/data/getSiteSettings.tsx
+++ b/src/data/getSiteSettings.tsx
@@ -135,6 +135,13 @@ export const getSiteSettings = (
             url: 'https://github.com/pluralsh/plural/releases',
           },
         },
+        {
+          id: 'security and compliance',
+          link: {
+            title: 'Security & Compliance',
+            url: 'https://app.secureframe.com/ext/trust-center/plural/',
+          },
+        },
       ],
     },
     company: {


### PR DESCRIPTION
@jsladerman I'm not currently able to run the marketing website locally but it seemed simple enough to add a new item to the Resources dropdown. Can you take a look?