### PR TITLE
kubecon announcement chip

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -175,6 +175,7 @@ function HeroImages({ ...props }: ComponentProps<typeof HeroImagesSC>) {
 export default function Index({
   articleCards,
   quotes,
+  announcementChip,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const [showVideo, setShowVideo] = useState(false)
 
@@ -208,6 +209,7 @@ export default function Index({
               enterprise scale with streamlined dependency management.
             </div>
           }
+          announcementChip={announcementChip}
           ctas={
             <div className="flex flex-wrap justify-center gap-large">
               <Button
@@ -353,6 +355,11 @@ export const getStaticProps = async () => {
       'Open-source application deployment, faster than ever without sacrificing compliance.',
     articleCards: data.page_homepage?.article_cards || null,
     quotes: normalizeQuotes(page?.quotes),
+    announcementChip: {
+      text: page?.announcement_text,
+      url: page?.announcement_url,
+      visible: page?.announcement_visible,
+    },
     footerVariant: FooterVariant.kitchenSink,
     errors: combineErrors([error]),
   })

--- a/src/components/AnnouncementChip.tsx
+++ b/src/components/AnnouncementChip.tsx
@@ -1,0 +1,43 @@
+import { ArrowTopRightIcon } from '@pluralsh/design-system'
+
+import styled from 'styled-components'
+
+export function AnnouncementChip({ text, url }: { text: string; url: string }) {
+  return (
+    <AnnouncementChipSC href={url}>
+      {text} <ArrowTopRightIcon />
+    </AnnouncementChipSC>
+  )
+}
+
+const AnnouncementChipSC = styled.a(({ theme }) => ({
+  '@property --bg-multiplier': {
+    syntax: "'<number>'",
+    inherits: 'false',
+    initialValue: '1',
+  },
+  ...theme.partials.text.overline,
+  position: 'relative',
+  width: 'fit-content',
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing.small,
+  padding: `${theme.spacing.medium}px ${theme.spacing.large}px`,
+  background: `linear-gradient(180deg, rgba(255, 255, 255, calc(0.15 * var(--bg-multiplier))) 0%, rgba(255, 255, 255, calc(0.04 * var(--bg-multiplier))) 100%)`,
+  borderRadius: '1000px',
+  transition: '--bg-multiplier 0.16s ease',
+  '&:hover': {
+    '--bg-multiplier': '1.75',
+  },
+  '&::before': {
+    borderRadius: '1000px',
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    border: '1px solid transparent',
+    background: `linear-gradient(to bottom, #747AF6, #454954) border-box`,
+    mask: 'linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0)',
+    maskComposite: 'exclude',
+  },
+}))

--- a/src/components/PageHeros.tsx
+++ b/src/components/PageHeros.tsx
@@ -7,6 +7,8 @@ import { StandardPageWidth } from '@src/components/layout/LayoutHelpers'
 import { TextLimiter } from '@src/components/layout/TextLimiter'
 import { cn as classNames } from '@src/utils/cn'
 
+import { AnnouncementChip } from './AnnouncementChip'
+
 export function HeroMainText({
   preHeading,
   heading,
@@ -117,10 +119,10 @@ export function HomePageHero({
   preHeading,
   heading,
   description,
-  // intro,
   padTop = true,
   padBottom = true,
   ctas,
+  announcementChip,
   ...props
 }: {
   preHeading?: ReactNode
@@ -129,13 +131,17 @@ export function HomePageHero({
   ctas?: ReactNode
   padTop?: boolean
   padBottom?: boolean
-  // intro?: ReactNode
+  announcementChip?: {
+    visible: Nullable<boolean>
+    text: Nullable<string>
+    url: Nullable<string>
+  }
 }) {
   return (
     <StandardPageWidth {...props}>
       <div
         className={classNames(
-          'text-center',
+          'flex flex-col items-center gap-large',
           {
             [classNames('pt-xxxxlarge', 'md:pt-xxxxlarge', 'lg:pt-xxxxxlarge')]:
               padTop,
@@ -146,6 +152,12 @@ export function HomePageHero({
           }
         )}
       >
+        {announcementChip?.visible && (
+          <AnnouncementChip
+            text={announcementChip.text ?? ''}
+            url={announcementChip.url ?? ''}
+          />
+        )}
         <HeroMainText
           preHeading={preHeading}
           heading={heading}

--- a/src/components/page-sections/ImpactCardSection.tsx
+++ b/src/components/page-sections/ImpactCardSection.tsx
@@ -57,13 +57,6 @@ function ImpactCard({
     <ImpactCardSC
       ref={cardRef}
       style={backgroundStyle}
-      css={`
-        @property --gradient-opacity {
-          syntax: '<number>';
-          inherits: false;
-          initial-value: 0.3;
-        }
-      `}
       $borderGradientDir={borderGradientDir}
     >
       {embellishment && (
@@ -104,6 +97,11 @@ const ImpactCardsWrapperSC = styled.div(({ theme }) => ({
 const ImpactCardSC = styled.div<{
   $borderGradientDir?: 'to right' | 'to left'
 }>(({ theme, $borderGradientDir }) => ({
+  '@property --gradient-opacity': {
+    syntax: "'<number>'",
+    inherits: 'false',
+    initialValue: '0.3',
+  },
   position: 'relative',
   borderRadius: theme.borderRadiuses.large,
   overflow: 'hidden',

--- a/src/generated/graphqlDirectus.ts
+++ b/src/generated/graphqlDirectus.ts
@@ -5474,6 +5474,9 @@ export type Create_Multi_Column_Text_Rich_Text_Columns_Input = {
 };
 
 export type Create_Page_Homepage_Input = {
+  announcement_text?: InputMaybe<Scalars['String']['input']>;
+  announcement_url?: InputMaybe<Scalars['String']['input']>;
+  announcement_visible?: InputMaybe<Scalars['Boolean']['input']>;
   article_cards?: InputMaybe<Array<InputMaybe<Create_Article_Cards_Input>>>;
   date_created?: InputMaybe<Scalars['Date']['input']>;
   date_updated?: InputMaybe<Scalars['Date']['input']>;
@@ -7122,6 +7125,9 @@ export type Number_Filter_Operators = {
 
 export type Page_Homepage = {
   __typename?: 'page_homepage';
+  announcement_text?: Maybe<Scalars['String']['output']>;
+  announcement_url?: Maybe<Scalars['String']['output']>;
+  announcement_visible?: Maybe<Scalars['Boolean']['output']>;
   article_cards?: Maybe<Array<Maybe<Article_Cards>>>;
   article_cards_func?: Maybe<Count_Functions>;
   date_created?: Maybe<Scalars['Date']['output']>;
@@ -7177,6 +7183,9 @@ export type Page_HomepageUser_UpdatedArgs = {
 export type Page_Homepage_Filter = {
   _and?: InputMaybe<Array<InputMaybe<Page_Homepage_Filter>>>;
   _or?: InputMaybe<Array<InputMaybe<Page_Homepage_Filter>>>;
+  announcement_text?: InputMaybe<String_Filter_Operators>;
+  announcement_url?: InputMaybe<String_Filter_Operators>;
+  announcement_visible?: InputMaybe<Boolean_Filter_Operators>;
   article_cards?: InputMaybe<Article_Cards_Filter>;
   article_cards_func?: InputMaybe<Count_Function_Filter_Operators>;
   date_created?: InputMaybe<Date_Filter_Operators>;
@@ -9118,6 +9127,9 @@ export type Update_Multi_Column_Text_Rich_Text_Columns_Input = {
 };
 
 export type Update_Page_Homepage_Input = {
+  announcement_text?: InputMaybe<Scalars['String']['input']>;
+  announcement_url?: InputMaybe<Scalars['String']['input']>;
+  announcement_visible?: InputMaybe<Scalars['Boolean']['input']>;
   article_cards?: InputMaybe<Array<InputMaybe<Update_Article_Cards_Input>>>;
   date_created?: InputMaybe<Scalars['Date']['input']>;
   date_updated?: InputMaybe<Scalars['Date']['input']>;
@@ -9513,12 +9525,12 @@ export type LegalPageSlugsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type LegalPageSlugsQuery = { __typename?: 'Query', page_legal?: { __typename?: 'page_legal', pages?: Array<{ __typename?: 'markdown_pages', slug?: string | null } | null> | null } | null };
 
-export type PageHomepageFragment = { __typename?: 'page_homepage', quotes?: { __typename?: 'quote_lists', slug: string, items?: Array<{ __typename?: 'quote_lists_items', item?: { __typename?: 'quotes', id: string, quote?: string | null, author_text?: string | null } | null } | null> | null } | null, article_cards?: Array<{ __typename?: 'article_cards', theme?: string | null, id: string, heading?: string | null, description?: string | null, videoUrl?: string | null, date?: any | null, author?: string | null, ctas?: any | null, url?: string | null, thumbnail?: { __typename?: 'directus_files', id: string, title?: string | null, description?: string | null, tags?: any | null, filename_disk?: string | null, filename_download: string, metadata?: any | null, type?: string | null, filesize?: any | null } | null } | null> | null };
+export type PageHomepageFragment = { __typename?: 'page_homepage', announcement_text?: string | null, announcement_url?: string | null, announcement_visible?: boolean | null, quotes?: { __typename?: 'quote_lists', slug: string, items?: Array<{ __typename?: 'quote_lists_items', item?: { __typename?: 'quotes', id: string, quote?: string | null, author_text?: string | null } | null } | null> | null } | null, article_cards?: Array<{ __typename?: 'article_cards', theme?: string | null, id: string, heading?: string | null, description?: string | null, videoUrl?: string | null, date?: any | null, author?: string | null, ctas?: any | null, url?: string | null, thumbnail?: { __typename?: 'directus_files', id: string, title?: string | null, description?: string | null, tags?: any | null, filename_disk?: string | null, filename_download: string, metadata?: any | null, type?: string | null, filesize?: any | null } | null } | null> | null };
 
 export type PageHomepageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type PageHomepageQuery = { __typename?: 'Query', page_homepage?: { __typename?: 'page_homepage', quotes?: { __typename?: 'quote_lists', slug: string, items?: Array<{ __typename?: 'quote_lists_items', item?: { __typename?: 'quotes', id: string, quote?: string | null, author_text?: string | null } | null } | null> | null } | null, article_cards?: Array<{ __typename?: 'article_cards', theme?: string | null, id: string, heading?: string | null, description?: string | null, videoUrl?: string | null, date?: any | null, author?: string | null, ctas?: any | null, url?: string | null, thumbnail?: { __typename?: 'directus_files', id: string, title?: string | null, description?: string | null, tags?: any | null, filename_disk?: string | null, filename_download: string, metadata?: any | null, type?: string | null, filesize?: any | null } | null } | null> | null } | null };
+export type PageHomepageQuery = { __typename?: 'Query', page_homepage?: { __typename?: 'page_homepage', announcement_text?: string | null, announcement_url?: string | null, announcement_visible?: boolean | null, quotes?: { __typename?: 'quote_lists', slug: string, items?: Array<{ __typename?: 'quote_lists_items', item?: { __typename?: 'quotes', id: string, quote?: string | null, author_text?: string | null } | null } | null> | null } | null, article_cards?: Array<{ __typename?: 'article_cards', theme?: string | null, id: string, heading?: string | null, description?: string | null, videoUrl?: string | null, date?: any | null, author?: string | null, ctas?: any | null, url?: string | null, thumbnail?: { __typename?: 'directus_files', id: string, title?: string | null, description?: string | null, tags?: any | null, filename_disk?: string | null, filename_download: string, metadata?: any | null, type?: string | null, filesize?: any | null } | null } | null> | null } | null };
 
 export const ImageFileFragmentDoc = gql`
     fragment ImageFile on directus_files {
@@ -9968,6 +9980,9 @@ export const PageHomepageFragmentDoc = gql`
   article_cards {
     ...MediaCardComponent
   }
+  announcement_text
+  announcement_url
+  announcement_visible
 }
     ${QuoteListFragmentDoc}
 ${MediaCardComponentFragmentDoc}`;

--- a/src/graph/directus/topLevelPages.graphql
+++ b/src/graph/directus/topLevelPages.graphql
@@ -33,6 +33,9 @@ fragment PageHomepage on page_homepage {
   article_cards {
     ...MediaCardComponent
   }
+  announcement_text
+  announcement_url
+  announcement_visible
 }
 
 query PageHomepage {


### PR DESCRIPTION
adds a cms-driven chip to the homepage, currently used for kubecon landing page link
![Screenshot 2024-11-06 at 6 35 45 PM](https://github.com/user-attachments/assets/99a613f7-4151-4c26-abf6-39d6a654bf16)
