### PR TITLE
fix docker routing bug

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,10 +25,6 @@ module.exports = () => {
       },
       emotion: true,
     },
-    i18n: {
-      locales: ['en-US'],
-      defaultLocale: 'en-US',
-    },
     pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdoc'],
     async redirects() {
       return [

--- a/src/components/HtmlHead.tsx
+++ b/src/components/HtmlHead.tsx
@@ -59,7 +59,7 @@ function OpenGraph({
       )}
       <meta
         property="og:url"
-        content={`${process.env.NEXT_PUBLIC_ROOT_URL}${router.pathname}`}
+        content={`${process.env.NEXT_PUBLIC_ROOT_URL}${router.asPath}`}
       />
     </Head>
   )


### PR DESCRIPTION
removes unused i18n which was causing all routing to happen server side and making things less snappy when running off the docker image. same issue we had on the docs site that was fixed in https://github.com/pluralsh/documentation/pull/462

also fixes an open graph issue we've always had where a templated url would be displayed by og_url instead of the resolved one