### PR TITLE
cta link fix

### DIFF
--- a/src/components/custom-page/CallToAction.tsx
+++ b/src/components/custom-page/CallToAction.tsx
@@ -20,8 +20,6 @@ export function CallToAction({
       <Button
         className="mt-medium"
         as={Link}
-        target="_blank"
-        rel="noopener noreferrer"
         href={ctaUrl}
       >
         {ctaText}


### PR DESCRIPTION
makes landing page cta's open links directly instead of in a new tab, which allows them to jump to other parts of the page

Plural Flow: marketing
Plural Preview: marketing