### PR TITLE
fix middleware and canonical link

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            NEXT_PUBLIC_SITE_URL="https://plural.sh"
+            NEXT_PUBLIC_SITE_URL="https://www.plural.sh"
             NEXT_PUBLIC_PRISMIC_ENVIRONMENT=${{ vars.NEXT_PUBLIC_PRISMIC_ENVIRONMENT }}
             NEXT_PUBLIC_GA_ID=${{ vars.NEXT_PUBLIC_GA_ID }}
             NEXT_PUBLIC_SITE_RECAPTCHA_KEY=${{ vars.NEXT_PUBLIC_SITE_RECAPTCHA_KEY }}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,8 +23,11 @@ export default async function middleware(request: NextRequest) {
   )
     return NextResponse.redirect(new URL('/not-found', request.url))
 
-  // skip i18n middleware for API routes and Next internal files/static assets
-  if (I18N_SKIP_LIST.some((route) => pathname.startsWith(route)))
+  // skip i18n middleware for API routes and Next internal files/static files (like robots.txt)
+  if (
+    I18N_SKIP_LIST.some((route) => pathname.startsWith(route)) ||
+    pathname.includes('.')
+  )
     return NextResponse.next()
 
   const [locales, defaultLocale] = await Promise.all([


### PR DESCRIPTION
changes in #169 didn't account for static files like sitemap and robots.txt
also fixes the injected canonical link

Plural Flow: marketing
Plural Preview: marketing