### PR TITLE
fix eyebrow width bug on mobile

### DIFF
--- a/src/components/ui/Eyebrow.tsx
+++ b/src/components/ui/Eyebrow.tsx
@@ -46,7 +46,7 @@ export default function Eyebrow<T extends LinkField | KeyTextField>({
       <PrismicNextLink
         field={field}
         className={cn(
-          'inline-flex items-center gap-x-3 rounded-lg px-3 py-2 whitespace-nowrap',
+          'inline-flex items-center gap-x-3 rounded-lg px-3 py-2',
           'text-caption group border transition',
           emphasized &&
             'bg-accent-100/5 border-accent-100/10 hover:border-accent-100/[24%] text-accent-100',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -48,7 +48,7 @@ export default async function middleware(request: NextRequest) {
 }
 
 const isMainProdSite = (request: NextRequest) => {
-  const requestOrigin = cleanUrl(request.nextUrl.origin)
+  const requestOrigin = cleanUrl(request.headers.get('host'))
   const prodOrigin = cleanUrl(process.env.NEXT_PUBLIC_SITE_URL)
   return !!requestOrigin && !!prodOrigin && requestOrigin === prodOrigin
 }


### PR DESCRIPTION
before:
<img width="574" height="800" alt="Screenshot 2025-08-27 at 3 40 38 PM" src="https://github.com/user-attachments/assets/4d736212-1ed1-4c35-971d-bb467f23ed72" />
after:
<img width="574" height="800" alt="Screenshot 2025-08-27 at 3 40 38 PM" src="https://github.com/user-attachments/assets/044da7c5-b892-4f1d-92eb-ce46141dc808" />
also makes a tweak because #170 wasn't quite working right within a docker container
Plural Flow: marketing
Plural Preview: marketing