### PR TITLE
add 10 min cache TTL

### DIFF
--- a/src/utils/prismicio.ts
+++ b/src/utils/prismicio.ts
@@ -42,7 +42,7 @@ export function createClient(config: ClientConfig = {}) {
     routes,
     fetchOptions:
       process.env.NODE_ENV === 'production'
-        ? { next: { tags: ['prismic'] }, cache: 'force-cache' }
+        ? { next: { tags: ['prismic'], revalidate: 600 } }
         : { next: { revalidate: 5 } },
     ...config,
   })


### PR DESCRIPTION
previously were using force-cache and relying on prismic's "publish" webhook to trigger an update. this works fine except that when the site is replicated on multiple pods, only the one that receives the webhook call actually updates. ultimately should implement a solution to that, but in the meantime the TTL at least ensures the pods are eventually consistent

Plural Flow: marketing
Plural Preview: marketing