### PR TITLE
hardcode locale information

### DIFF
--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -1,0 +1,5 @@
+// we were previously fetching these dynamically from Prismic, but it caused our api usage to skyrocket
+// these will rarely change, and if we add want to add a new language we can just update it here
+export const SUPPORTED_LOCALES = ['en-us'] as const
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+export const DEFAULT_LOCALE: SupportedLocale = 'en-us'

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,21 +1,15 @@
 import { getRequestConfig } from 'next-intl/server'
-
 import {
-  getPrismicDefaultLanguage,
-  getPrismicLanguages,
-} from '@/utils/prismicio'
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  type SupportedLocale,
+} from '@/i18n/locales'
 
 export default getRequestConfig(async ({ requestLocale }) => {
-  const languages = await getPrismicLanguages()
-  const defaultLanguage = await getPrismicDefaultLanguage()
-
-  // This typically corresponds to the `[locale]` segment
   let locale = await requestLocale
 
-  // Ensure that a valid locale is used
-  if (!locale || !languages.includes(locale)) {
-    locale = defaultLanguage
-  }
+  if (!locale || !SUPPORTED_LOCALES.includes(locale as SupportedLocale))
+    locale = DEFAULT_LOCALE
 
   return {
     locale,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,11 +2,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
 import createMiddleware from 'next-intl/middleware'
-
-import {
-  getPrismicDefaultLanguage,
-  getPrismicLanguages,
-} from '@/utils/prismicio'
+import { SUPPORTED_LOCALES, DEFAULT_LOCALE } from '@/i18n/locales'
 
 import { HEADERS } from './constants'
 
@@ -16,7 +12,7 @@ const I18N_SKIP_LIST = ['/api', '/slice-library', '/slice-simulator', '/_next']
 export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  // block prismic-related stuff on main prod site
+  // block prismic dev related stuff on main prod site
   if (
     process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod' &&
     PROD_BLOCK_LIST.some((route) => pathname.startsWith(route))
@@ -30,19 +26,14 @@ export default async function middleware(request: NextRequest) {
   )
     return NextResponse.next()
 
-  const [locales, defaultLocale] = await Promise.all([
-    getPrismicLanguages(),
-    getPrismicDefaultLanguage(),
-  ])
-
   const handleI18nRouting = createMiddleware({
-    locales,
-    defaultLocale,
+    locales: SUPPORTED_LOCALES,
+    defaultLocale: DEFAULT_LOCALE,
     localeDetection: false,
     localePrefix: 'as-needed',
   })
   const response = handleI18nRouting(request)
-  response.headers.set(HEADERS.DEFAULT_LOCALE, defaultLocale)
+  response.headers.set(HEADERS.DEFAULT_LOCALE, DEFAULT_LOCALE)
 
   return response
 }


### PR DESCRIPTION
this will rarely change (if ever) so we definitely don't need it fetched from the api on every request. hopefully should cut our prismic api usage 2-3x

Plural Flow: marketing
Plural Preview: marketing