### PR TITLE
fix: bump slice-machine-ui to 2.21.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "postcss": "8.5.10",
         "prettier": "3.6.2",
         "prettier-plugin-tailwindcss": "0.6.14",
-        "slice-machine-ui": "2.21.1",
+        "slice-machine-ui": "2.21.2",
         "tailwindcss": "4.2.1",
         "typescript": "5.8.3",
         "typescript-eslint": "8.56.1"
@@ -197,6 +197,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -214,6 +217,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -231,6 +237,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -248,6 +257,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -271,6 +283,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -294,6 +309,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4112,9 +4130,9 @@
       }
     },
     "node_modules/@slicemachine/manager": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@slicemachine/manager/-/manager-0.27.1.tgz",
-      "integrity": "sha512-IlzDrxzlQTL8c4axVUUtLM0qtAfSaRtSS9US/qAc+Xpy/xBgCVvuZZ6jVqqb4KHHx4bDSHkemvM4JJb2PKAUZg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@slicemachine/manager/-/manager-0.27.2.tgz",
+      "integrity": "sha512-+b6wjJpJfg8DaO3W2OYCRok9fBWYz9oqEg2qHbUJPdX43TD+NmFXvpi2YRZ6pDBe0X1hVh2C43WIIbDMdVQ8kg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4125,14 +4143,14 @@
         "@prismicio/mocks": "2.14.0",
         "@prismicio/types-internal": "3.11.2",
         "@segment/analytics-node": "^2.1.2",
-        "@slicemachine/plugin-kit": "0.4.93",
+        "@slicemachine/plugin-kit": "0.4.94",
         "cookie": "^1.0.1",
         "cors": "^2.8.5",
         "execa": "^7.1.1",
         "file-type": "^18.2.1",
         "fp-ts": "^2.13.1",
         "get-port": "^6.1.2",
-        "h3": "^1.15.5",
+        "h3": "^1.15.6",
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
@@ -4206,9 +4224,9 @@
       }
     },
     "node_modules/@slicemachine/manager/node_modules/@slicemachine/plugin-kit": {
-      "version": "0.4.93",
-      "resolved": "https://registry.npmjs.org/@slicemachine/plugin-kit/-/plugin-kit-0.4.93.tgz",
-      "integrity": "sha512-9LCFHouGbedmsQRUvcD6JU6/GxNxp0QUnoUHbgYFmKQSWTApXDWqPIRr1ejTRYDqLc4hg7FURiHT3tx7bDK+XA==",
+      "version": "0.4.94",
+      "resolved": "https://registry.npmjs.org/@slicemachine/plugin-kit/-/plugin-kit-0.4.94.tgz",
+      "integrity": "sha512-u41UpWrzkLfa/dYzpaKlCJn8mru9mh3k+2PxnPagTOceQMMMZP/mA7NVUc4ee5uzAgt1z6m8759XcjKh7QFBKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4781,6 +4799,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
@@ -5972,9 +6054,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5986,7 +6068,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -7798,15 +7880,15 @@
       "license": "ISC"
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -7825,7 +7907,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -8681,9 +8763,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10038,9 +10120,9 @@
       }
     },
     "node_modules/lorem-ipsum": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.8.tgz",
-      "integrity": "sha512-5RIwHuCb979RASgCJH0VKERn9cQo/+NcAi2BMe9ddj+gp7hujl6BI+qdOG4nVsLDpwWEJwTVYXNKP6BGgbcoGA==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.10.tgz",
+      "integrity": "sha512-+Vju4QAN6l2SX9tQ4Dm+mg1qgxf8IzqFh35h/dtFLofW+QHKunMjANfuhlx3vO9+LFetGRtqzvOlpw+1ysDeTw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11089,9 +11171,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
     },
@@ -11453,13 +11535,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -12484,15 +12567,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -12504,14 +12587,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12603,14 +12686,14 @@
       }
     },
     "node_modules/slice-machine-ui": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/slice-machine-ui/-/slice-machine-ui-2.21.1.tgz",
-      "integrity": "sha512-r+9h968zkh7VvNmLn2AVtcpSHwscy1+nGtPBEzMepItjHT6lPMOdKBAayaqRZAzy5yaJbnKhVV6g73gOgSmCoQ==",
+      "version": "2.21.2",
+      "resolved": "https://registry.npmjs.org/slice-machine-ui/-/slice-machine-ui-2.21.2.tgz",
+      "integrity": "sha512-l4Tw2h7EYGORFdrc21rLoDoM02CJNCY+RfY5meZJDyyRUNvUfInGiDytVR3Vvwhkt5IKSKKP/BGC5bvUorAJKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@slicemachine/manager": "0.27.1",
-        "start-slicemachine": "0.12.73"
+        "@slicemachine/manager": "0.27.2",
+        "start-slicemachine": "0.12.74"
       },
       "bin": {
         "start-slicemachine": "bin/start-slicemachine.cjs"
@@ -12684,15 +12767,15 @@
       "license": "MIT"
     },
     "node_modules/start-slicemachine": {
-      "version": "0.12.73",
-      "resolved": "https://registry.npmjs.org/start-slicemachine/-/start-slicemachine-0.12.73.tgz",
-      "integrity": "sha512-Nu8+kUbCmvykAHWF69mLulWODmQofdiAu3rrwPa5QT8021M0qgrYir1e7QA9HoRrjPsLmC4fstlBWgyAnbXmYw==",
+      "version": "0.12.74",
+      "resolved": "https://registry.npmjs.org/start-slicemachine/-/start-slicemachine-0.12.74.tgz",
+      "integrity": "sha512-UQeiBTWR1nZfvk2PtseHtxAbMymRSEVlAFqRTnUJOkWAnYL3QduwGpd6RLOFsouylUiEmEqJomqhx3LUHphzIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prismicio/mocks": "2.14.0",
         "@prismicio/types-internal": "3.11.2",
-        "@slicemachine/manager": "0.27.1",
+        "@slicemachine/manager": "0.27.2",
         "body-parser": "^1.20.3",
         "chalk": "^4.1.2",
         "cors": "^2.8.5",
@@ -13468,9 +13551,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "postcss": "8.5.10",
     "prettier": "3.6.2",
     "prettier-plugin-tailwindcss": "0.6.14",
-    "slice-machine-ui": "2.21.1",
+    "slice-machine-ui": "2.21.2",
     "tailwindcss": "4.2.1",
     "typescript": "5.8.3",
     "typescript-eslint": "8.56.1"


### PR DESCRIPTION
## Summary
- bump `slice-machine-ui` from `2.21.1` to `2.21.2` in `package.json`
- regenerate `package-lock.json` with npm to update the dev-only Slice Machine chain
- remove the confirmed vulnerable path `slice-machine-ui@2.21.1 -> start-slicemachine@0.12.73 -> express@4.22.1 -> path-to-regexp@0.1.12`

## Details
- smallest owning direct dependency bump selected: `slice-machine-ui 2.21.1 -> 2.21.2`
- resulting transitive chain in the lockfile: `start-slicemachine 0.12.74 -> express 4.22.2 -> path-to-regexp 0.1.13`
- files changed: `package.json`, `package-lock.json`
- no application source files changed

## Validation
- `npm install --package-lock-only --ignore-scripts` in `node:24` Docker to regenerate the lockfile
- `npm ls slice-machine-ui start-slicemachine express path-to-regexp --package-lock-only --all` in `node:24` Docker confirmed the updated chain

## Notes
- a plain `npm install --package-lock-only` attempt triggered the repo `prepare` script (`husky`) before dependencies were present in the container, so the lockfile regeneration was rerun with `--ignore-scripts`
- other unrelated audit findings remain and were intentionally left out of scope