### PR TITLE
fix(hero): tune video demo frame size and Supademo fit

### DIFF
--- a/src/components/video-demo/VideoDemoFrame.module.css
+++ b/src/components/video-demo/VideoDemoFrame.module.css
@@ -6,10 +6,11 @@
   --demo-fit-scale-y: 1.01;
 
   position: relative;
+  /* Explicit width + height (not aspect-ratio): with the current caps the
+     width clamp always wins, so a declared ratio would be dead CSS. These
+     match the visually tuned frame: 910px wide, 690px/68svh tall. */
+  width: min(100%, var(--video-demo-max-width));
   height: min(var(--video-demo-max-height), var(--video-demo-max-height-svh));
-  width: auto;
-  max-width: min(100%, var(--video-demo-max-width));
-  aspect-ratio: 12 / 5;
   margin: 0 auto;
   /* Tab bar hangs 50% below the frame — leave room so it isn't clipped. */
   margin-bottom: 3rem;
@@ -38,14 +39,11 @@
   position: absolute;
   left: 50%;
   top: 50%;
-  width: calc(100% / var(--demo-fit-scale-x, var(--demo-fit-scale, 1)));
-  height: calc(100% / var(--demo-fit-scale-y, var(--demo-fit-scale, 1)));
+  width: calc(100% / var(--demo-fit-scale-x, 1));
+  height: calc(100% / var(--demo-fit-scale-y, 1));
   border: 0;
   transform: translate(-50%, -50%)
-    scale(
-      var(--demo-fit-scale-x, var(--demo-fit-scale, 1)),
-      var(--demo-fit-scale-y, var(--demo-fit-scale, 1))
-    );
+    scale(var(--demo-fit-scale-x, 1), var(--demo-fit-scale-y, 1));
   transform-origin: center center;
 }
 

--- a/src/components/video-demo/VideoDemoFrame.module.css
+++ b/src/components/video-demo/VideoDemoFrame.module.css
@@ -1,10 +1,18 @@
-/* Compact frame sized to fit under the hero like Railway */
 .showcaseFrame {
+  --video-demo-max-width: 910px;
+  --video-demo-max-height: 690px;
+  --video-demo-max-height-svh: 68svh;
+  --demo-fit-scale-x: 1;
+  --demo-fit-scale-y: 1.01;
+
   position: relative;
-  width: min(100%, calc(min(520px, 55svh) * 1.6));
+  height: min(var(--video-demo-max-height), var(--video-demo-max-height-svh));
+  width: auto;
+  max-width: min(100%, var(--video-demo-max-width));
+  aspect-ratio: 12 / 5;
   margin: 0 auto;
-  /* Room for the tab bar hanging off the bottom edge */
-  margin-bottom: 2rem;
+  /* Tab bar hangs 50% below the frame — leave room so it isn't clipped. */
+  margin-bottom: 3rem;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: #0e1015;
@@ -15,32 +23,30 @@
 .demoViewport {
   position: relative;
   width: 100%;
-  height: min(520px, 55svh);
+  height: 100%;
   overflow: hidden;
   border-radius: 12px;
   background: #0e1015;
 }
 
-.demoViewport iframe {
-  position: absolute;
-  inset: 0;
-  display: block;
-  width: 100%;
-  height: 100%;
-  border: 0;
-}
-
-/* Optional zoom: scale the embed up inside the clipped viewport */
-.demoPanel iframe {
-  width: calc(100% / var(--demo-scale, 1));
-  height: calc(100% / var(--demo-scale, 1));
-  transform: scale(var(--demo-scale, 1));
-  transform-origin: top left;
-}
-
 .demoPanel {
   position: absolute;
   inset: 0;
+}
+
+.demoPanel iframe {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: calc(100% / var(--demo-fit-scale-x, var(--demo-fit-scale, 1)));
+  height: calc(100% / var(--demo-fit-scale-y, var(--demo-fit-scale, 1)));
+  border: 0;
+  transform: translate(-50%, -50%)
+    scale(
+      var(--demo-fit-scale-x, var(--demo-fit-scale, 1)),
+      var(--demo-fit-scale-y, var(--demo-fit-scale, 1))
+    );
+  transform-origin: center center;
 }
 
 .demoPanelHidden {
@@ -187,12 +193,7 @@
 
 @media (max-width: 720px) {
   .showcaseFrame {
-    width: min(100%, calc(min(360px, 50svh) * 1.6));
     margin-bottom: 1.75rem;
-  }
-
-  .demoViewport {
-    height: min(360px, 50svh);
   }
 
   .tabNav {

--- a/src/components/video-demo/VideoDemoFrame.tsx
+++ b/src/components/video-demo/VideoDemoFrame.tsx
@@ -86,8 +86,6 @@ export default function VideoDemoFrame({ className }: VideoDemoFrameProps) {
       style={
         {
           '--video-demo-tab-ms': `${tabDurationMs}ms`,
-          // 1 = natural size; >1 zooms the Supademo UI (crops edges)
-          '--demo-scale': 1.05,
         } as React.CSSProperties
       }
     >

--- a/src/slices/main/Hero/HeroExclusiveVideoDemoMedia.tsx
+++ b/src/slices/main/Hero/HeroExclusiveVideoDemoMedia.tsx
@@ -42,10 +42,8 @@ export default function HeroExclusiveVideoDemoMedia({
 
   if (showDemo) {
     return (
-      <div className="my-3 flex w-full justify-center px-4 md:px-0">
-        <div className="w-full max-w-[1080px] md:w-[72%]">
-          <VideoDemoFrame />
-        </div>
+      <div className="flex w-full justify-center px-4 md:px-6">
+        <VideoDemoFrame />
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Retune the hero video demo frame to a 12:5 aspect ratio with tuned max width/height caps so the border hugs the Supademo embed.
- Add separate X/Y fit scales to trim letterboxing without squashing content.
- Simplify the hero media wrapper so sizing is controlled by the frame component.

## Test plan
- [ ] Open homepage on desktop (≥1080px) and confirm the video demo frame fits the Supademo UI without side gutters
- [ ] Cycle through all four demo tabs and verify content is not clipped top/bottom
- [ ] Check on a short laptop viewport (e.g. 1280×800) that the frame respects `68svh` max height
- [ ] Confirm mobile (<1080px) still shows the static hero image fallback


Made with [Cursor](https://cursor.com)

Plural Preview: marketing
Plural Flow: marketing